### PR TITLE
#56 mint calls new generate_V2 route that does watermark protection b…

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@itheum/sdk-mx-data-nft",
-  "version": "2.0.0-alpha.1",
+  "version": "2.1.0-alpha.1",
   "description": "SDK for Itheum's Data NFT Technology on MultiversX Blockchain",
   "main": "out/index.js",
   "types": "out/index.d.js",

--- a/src/common/mint-utils.ts
+++ b/src/common/mint-utils.ts
@@ -2,7 +2,8 @@ import { NFTStorage, File } from 'nft.storage';
 
 export async function dataNFTDataStreamAdvertise(
   dataNFTStreamUrl: string,
-  dataMarshalUrl: string
+  dataMarshalUrl: string,
+  dataCreatorAddress: string
 ): Promise<{ dataNftHash: string; dataNftStreamUrlEncrypted: string }> {
   const myHeaders = new Headers();
   myHeaders.append('cache-control', 'no-cache');
@@ -11,11 +12,14 @@ export async function dataNFTDataStreamAdvertise(
   const requestOptions = {
     method: 'POST',
     headers: myHeaders,
-    body: JSON.stringify({ dataNFTStreamUrl })
+    body: JSON.stringify({
+      dataNFTStreamUrl,
+      dataCreatorERDAddress: dataCreatorAddress
+    })
   };
 
   try {
-    const res = await fetch(`${dataMarshalUrl}/generate`, requestOptions);
+    const res = await fetch(`${dataMarshalUrl}/generate_V2`, requestOptions);
     const data = await res.json();
 
     if (data && data.encryptedMessage && data.messageHash) {

--- a/src/nft-minter.ts
+++ b/src/nft-minter.ts
@@ -226,7 +226,11 @@ export class NftMinter extends Minter {
     let metadataOnIpfsUrl: string;
 
     const { dataNftHash, dataNftStreamUrlEncrypted } =
-      await dataNFTDataStreamAdvertise(dataStreamUrl, dataMarshalUrl);
+      await dataNFTDataStreamAdvertise(
+        dataStreamUrl,
+        dataMarshalUrl,
+        senderAddress.bech32()
+      );
 
     if (!imageUrl) {
       if (!nftStorageToken) {

--- a/src/sft-minter.ts
+++ b/src/sft-minter.ts
@@ -216,7 +216,11 @@ export class SftMinter extends Minter {
     let metadataOnIpfsUrl: string;
 
     const { dataNftHash, dataNftStreamUrlEncrypted } =
-      await dataNFTDataStreamAdvertise(dataStreamUrl, dataMarshalUrl);
+      await dataNFTDataStreamAdvertise(
+        dataStreamUrl,
+        dataMarshalUrl,
+        senderAddress.bech32()
+      );
 
     if (!imageUrl) {
       if (!nftStorageToken) {

--- a/tests/datanft.test.ts
+++ b/tests/datanft.test.ts
@@ -15,8 +15,7 @@ describe('Data NFT test', () => {
   test('#test not setting network config', async () => {
     try {
       const dataNft = new DataNft({
-        dataMarshal:
-          'https://api.itheumcloud-stg.com/datamarshalapi/achilles/v1'
+        dataMarshal: 'https://api.itheumcloud-stg.com/datamarshalapi/router/v1'
       });
 
       await dataNft.viewData({
@@ -48,7 +47,7 @@ describe('Data NFT test', () => {
   test('#getMessageToSign', async () => {
     DataNft.setNetworkConfig('devnet');
     const dataNft = new DataNft({
-      dataMarshal: 'https://api.itheumcloud-stg.com/datamarshalapi/achilles/v1'
+      dataMarshal: 'https://api.itheumcloud-stg.com/datamarshalapi/router/v1'
     });
 
     const nonceToSign = await dataNft.getMessageToSign();

--- a/tests/nftminter.test.ts
+++ b/tests/nftminter.test.ts
@@ -47,7 +47,7 @@ describe('Nft minter test', () => {
     const mintTx = await nftMinter.mint(
       senderAddress,
       'TokenName',
-      'https://d37x5igq4vw5mq.cloudfront.net/datamarshalapi/achilles/v1',
+      'https://d37x5igq4vw5mq.cloudfront.net/datamarshalapi/router/v1',
       'https://raw.githubusercontent.com/Itheum/data-assets/main/Health/H1__Signs_of_Anxiety_in_American_Households_due_to_Covid19/dataset.json',
       'https://itheumapi.com/programReadingPreview/70dc6bd0-59b0-11e8-8d54-2d562f6cba54',
       1000,
@@ -74,7 +74,7 @@ describe('Nft minter test', () => {
     const mintTx = await nftMinter.mint(
       senderAddress,
       'TokenName',
-      'https://d37x5igq4vw5mq.cloudfront.net/datamarshalapi/achilles/v1',
+      'https://d37x5igq4vw5mq.cloudfront.net/datamarshalapi/router/v1',
       'https://raw.githubusercontent.com/Itheum/data-assets/main/Health/H1__Signs_of_Anxiety_in_American_Households_due_to_Covid19/dataset.json',
       'https://itheumapi.com/programReadingPreview/70dc6bd0-59b0-11e8-8d54-2d562f6cba54',
       1000,
@@ -102,7 +102,7 @@ describe('Nft minter test', () => {
     const mintTx = await nftMinter.mint(
       senderAddress,
       'TokenName',
-      'https://d37x5igq4vw5mq.cloudfront.net/datamarshalapi/achilles/v1',
+      'https://d37x5igq4vw5mq.cloudfront.net/datamarshalapi/router/v1',
       'https://raw.githubusercontent.com/Itheum/data-assets/main/Health/H1__Signs_of_Anxiety_in_American_Households_due_to_Covid19/dataset.json',
       'https://itheumapi.com/programReadingPreview/70dc6bd0-59b0-11e8-8d54-2d562f6cba54',
       1000,


### PR DESCRIPTION
…y taking the sender and watermarking them as the data creator on the encrypted payload that goes onchain. also replace achilles with router for the data marshal urls used in tests